### PR TITLE
Install libicu-dev; add alert, remove spinners

### DIFF
--- a/shiny-openFlow/Dockerfile
+++ b/shiny-openFlow/Dockerfile
@@ -16,10 +16,10 @@ RUN chmod +x entrypoint.sh
 #   maketools::package_sysdeps("package_name")
 # on a linux system with the required R package already installed
 # the dependencies below already included in the shiny-verse image
-#RUN apt-get update && apt-get install -y --no-install-recommends \ 
-	#libstdc++6 \
-    #&& apt-get clean \
-    #&& rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \ 
+		libicu-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # remotes::install_deps relies on the contents of src/DESCRIPTION
 # and it must be copied to the container before running this command

--- a/shiny-openFlow/src/about.Rmd
+++ b/shiny-openFlow/src/about.Rmd
@@ -189,7 +189,13 @@ When hovering on the timeseries plot along the x-axis, the two lower plots will 
 
 <center><font size="2">Interpreting the Real-Time Data Viewer outputs: The discharge value that is reported from a single reading or that is currently highlighted in the timeseries will render in the rating curve plot as a horizontal dashed black line. The stream stage that that discharge corresponds to will be shown as how 'full' the channel is in the discharge cross section plot.</font></center>
 
+## <span style="color: #2F5597;"><b>Citing openFlow & Downloaded Figures</b></span>
+
+The NEON program details citation guidelines of various forms of NEON products on the NEON webpage ["Acknowledging and Citing NEON"](https://www.neonscience.org/data/guidelines-policies/citing). Users that cite the use of the openFlow app, or use downloaded plots and/or figures, should follow NEON citation guidelines. See the "Webpages and Blogs" section for citing the openFlow app itself. See "Images and Graphics" for citing downloaded plots/figures.
+
 ## <span style="color: #2F5597;"><b>Change Log</b></span>
+
+2026-04-15: Added citation information to user guide.
 
 2026-04-07: Remove dependency on non-CRAN openFlowInternal package, which was causing public app to crash. Migrate functionality of openFlowInternal to populate external DB tables. Update UI to provide title and short description of each tab.
 
@@ -235,7 +241,7 @@ Is the app not working as expected? Do you have an enhancement request for the a
 
 ### Credits & Acknowledgements
 
-Author: Zachary Nickerson, NEON Ecologist II - email: nickerson@battelleecology.org
+Author: Zachary Nickerson, NEON Ecologist II - [_Contact author_](https://www.neonscience.org/about/contact-us)
 
 Contributors:
 
@@ -261,4 +267,4 @@ GNU AFFERO GENERAL PUBLIC LICENSE Version 3, 19 November 2007
 
 *Information and documents contained within this package are available as-is. Codes or documents, or their use, may not be supported or maintained under any program or service and may not be compatible with data currently available from the NEON Data Portal.*
 
-_Last Updated: 2026-04-07_
+_Last Updated: 2026-04-15_

--- a/shiny-openFlow/src/server.R
+++ b/shiny-openFlow/src/server.R
@@ -39,6 +39,14 @@ server <- function(input, output, session) {
 
   # 4 Process inputs & generate outputs ####
   shiny::observeEvent(input$submit,{
+    shinyWidgets::sendSweetAlert(
+      session = session,
+      title = "Building Plot Based on Inputs",
+      text = "Click 'OK' when plot appears to start exploring NEON hydrology data!",
+      type = "info",
+      closeOnEsc = FALSE, #prevents closing the box with the Esc key
+      closeOnClickOutside = FALSE # prevents the user from clicking outside the box
+    )
     
     #. . 4.1 Isolate inputs ####
     TS_siteID <- shiny::isolate(input$siteId)

--- a/shiny-openFlow/src/ui.R
+++ b/shiny-openFlow/src/ui.R
@@ -75,9 +75,9 @@ ui<- shinydashboard::dashboardPage(
                                                shiny::column(10,
                                                              shiny::tabsetPanel(type = "tabs",id = "selectedTab",
                                                                                 shiny::tabPanel("Continuous Discharge",
-                                                                                                shinycssloaders::withSpinner(plotly::plotlyOutput("plot1",height="800px"))),
+                                                                                                plotly::plotlyOutput("plot1",height="800px")),
                                                                                 shiny::tabPanel("Rating Curve(s)",
-                                                                                                shinycssloaders::withSpinner(plotly::plotlyOutput("plot2",height="800px")))
+                                                                                                plotly::plotlyOutput("plot2",height="800px"))
                                                                                 )# End tabsetPanel
                                                              )# End second column
                                                )# End fluid row for timeseries viewer,


### PR DESCRIPTION
Dockerfile: install libicu-dev to satisfy system dependencies and clean apt lists. server.R: show a SweetAlert on submit to inform users that the plot is being built (UX improvement; disables Esc/click-to-close). ui.R: remove shinycssloaders::withSpinner wrappers around Plotly outputs. about.Rmd: add a section on citing openFlow and downloaded figures, update author contact link and change log/last-updated date. These changes address runtime dependency needs and improve user feedback and documentation.